### PR TITLE
Nm/cs 289 precall test

### DIFF
--- a/compatibility.js
+++ b/compatibility.js
@@ -21,5 +21,5 @@ export default {
   isWindows: () => bowser.windows,
 
   // Occurs on iOS Safari when loaded in an in-app browser
-  isUnsupportedBrowserFrame: () => !!bowser.ios && !window.navigator.mediaDevices,
+  isUnsupportedBrowserFrame: () => !!bowser.ios && !window.navigator.mediaDevices && !bowser.chrome,
 }

--- a/compatible-browsers.json
+++ b/compatible-browsers.json
@@ -8,11 +8,11 @@
     "samsungBrowser": "8.2"
   },
   "latest": {
-    "chrome": "74",
-    "firefox": "66",
-    "opera": "58",
-    "safari": "12.1",
+    "chrome": "81",
+    "firefox": "75",
+    "opera": "66",
+    "safari": "13.4",
     "samsung": "9.2",
-    "samsungBrowser": "9.2"
+    "samsungBrowser": "11.1"
   }
 }

--- a/compatible-browsers.json
+++ b/compatible-browsers.json
@@ -8,11 +8,11 @@
     "samsungBrowser": "8.2"
   },
   "latest": {
-    "chrome": "81",
-    "firefox": "75",
-    "opera": "66",
-    "safari": "13.4",
+    "chrome": "74",
+    "firefox": "66",
+    "opera": "58",
+    "safari": "12.1",
     "samsung": "9.2",
-    "samsungBrowser": "11.1"
+    "samsungBrowser": "9.2"
   }
 }


### PR DESCRIPTION
fixed isUnsupportedBrowserFrame condition to avoid "Chrome browser unsupported" message in iOS.